### PR TITLE
Make it possible to compile messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 node_modules
 _book
-
+*~

--- a/protobuf/AudioFormatSettings.proto
+++ b/protobuf/AudioFormatSettings.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 message AudioFormatSettings {
   optional bytes formatSettingsPlistData = 1;
 }

--- a/protobuf/ClientUpdatesConfigMessage.proto
+++ b/protobuf/ClientUpdatesConfigMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 
 extend ProtocolMessage {

--- a/protobuf/CryptoPairingMessage.proto
+++ b/protobuf/CryptoPairingMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 
 extend ProtocolMessage {

--- a/protobuf/DeviceInfoMessage.proto
+++ b/protobuf/DeviceInfoMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 
 extend ProtocolMessage {

--- a/protobuf/GetKeyboardSessionMessage.proto
+++ b/protobuf/GetKeyboardSessionMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 
 extend ProtocolMessage {

--- a/protobuf/KeyboardMessage.proto
+++ b/protobuf/KeyboardMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 import "TextEditingAttributes.proto";
 

--- a/protobuf/NotificationMessage.proto
+++ b/protobuf/NotificationMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 
 extend ProtocolMessage {

--- a/protobuf/ProtocolMessage.proto
+++ b/protobuf/ProtocolMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 message ProtocolMessage {
   extensions 6 to max;
 

--- a/protobuf/RegisterForGameControllerEventsMessage.proto
+++ b/protobuf/RegisterForGameControllerEventsMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 
 extend ProtocolMessage {

--- a/protobuf/RegisterHIDDeviceMessage.proto
+++ b/protobuf/RegisterHIDDeviceMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 import "VirtualTouchDeviceDescriptor.proto";
 

--- a/protobuf/RegisterHIDDeviceResultMessage.proto
+++ b/protobuf/RegisterHIDDeviceResultMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 
 extend ProtocolMessage {

--- a/protobuf/RegisterVoiceInputDeviceMessage.proto
+++ b/protobuf/RegisterVoiceInputDeviceMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 import "VoiceInputDeviceDescriptor.proto";
 

--- a/protobuf/RegisterVoiceInputDeviceResponseMessage.proto
+++ b/protobuf/RegisterVoiceInputDeviceResponseMessage.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "ProtocolMessage.proto";
 
 extend ProtocolMessage {

--- a/protobuf/TextEditingAttributes.proto
+++ b/protobuf/TextEditingAttributes.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "TextInputTraits.proto";
 
 message TextEditingAttributes {

--- a/protobuf/TextInputTraits.proto
+++ b/protobuf/TextInputTraits.proto
@@ -1,49 +1,51 @@
+syntax = "proto2";
+
 message TextInputTraits {
   enum AutocapitalizationType {
-    NONE = 0,
-    WORDS = 1,
-    SENTENCES = 2,
-    CHARACTERS = 3,
+    NONE = 0;
+    WORDS = 1;
+    SENTENCES = 2;
+    CHARACTERS = 3;
   }
 
   enum KeyboardType {
-    DEFAULT = 0,
-    ASCII_CAPABLE = 1,
-    NUMBERS_AND_PUNCTUATION = 2,
-    URL = 3,
-    NUMBER_PAD = 4,
-    PHONE_PAD = 5,
-    NAME_PHONE_PAD = 6,
-    EMAIL_ADDRESS = 7,
-    DECIMAL_PAD = 8,
-    TWITTER = 9,
-    WEB_SEARCH = 10,
-    // ALPHABET = 1,
+    KEYBOARD_TYPE_DEFAULT = 0;
+    ASCII_CAPABLE = 1;
+    NUMBERS_AND_PUNCTUATION = 2;
+    URL = 3;
+    NUMBER_PAD = 4;
+    PHONE_PAD = 5;
+    NAME_PHONE_PAD = 6;
+    EMAIL_ADDRESS = 7;
+    DECIMAL_PAD = 8;
+    TWITTER = 9;
+    WEB_SEARCH = 10;
+    // ALPHABET = 1;
   }
 
   enum ReturnKeyType {
-    DEFAULT = 0,
-    GO = 1,
-    GOOGLE = 2,
-    JOIN = 3,
-    NEXT = 4,
-    ROUTE = 5,
-    SEARCH = 6,
-    SEND = 7,
-    YAHOO = 8,
-    DONE = 9,
-    EMERGENCY_CALL = 10,
-    CONTINUE = 11,
+    RETURN_KEY_DEFAULT = 0;
+    GO = 1;
+    GOOGLE = 2;
+    JOIN = 3;
+    NEXT = 4;
+    ROUTE = 5;
+    SEARCH = 6;
+    SEND = 7;
+    YAHOO = 8;
+    DONE = 9;
+    EMERGENCY_CALL = 10;
+    CONTINUE = 11;
   }
 
-  optional AutocapitalizationType autocapitalizationType = ?;
-  optional bool autocorrection = ?;
-  repeated int64 PINEntrySeparatorIndexes = ?;
-  optional bool enablesReturnKeyAutomatically = ?;
-  optional KeyboardType keyboardType = ?;
-  optional ReturnKeyType returnKeyType = ?; 
-  optional bool secureTextEntry = ?;
-  optional bool spellchecking = ?;
-  optional int32 validTextRangeLength = ?;
-  optional int32 validTextRangeLocation = ?;
+//   optional AutocapitalizationType autocapitalizationType = ?;
+//   optional bool autocorrection = ?;
+//   repeated int64 PINEntrySeparatorIndexes = ?;
+//   optional bool enablesReturnKeyAutomatically = ?;
+//   optional KeyboardType keyboardType = ?;
+//   optional ReturnKeyType returnKeyType = ?;
+//   optional bool secureTextEntry = ?;
+//   optional bool spellchecking = ?;
+//   optional int32 validTextRangeLength = ?;
+//   optional int32 validTextRangeLocation = ?;
 }

--- a/protobuf/VirtualTouchDeviceDescriptor.proto
+++ b/protobuf/VirtualTouchDeviceDescriptor.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 message VirtualTouchDeviceDescriptor {
   optional bool absolute = 1;
   optional bool integratedDisplay = 2;

--- a/protobuf/VoiceInputDeviceDescriptor.proto
+++ b/protobuf/VoiceInputDeviceDescriptor.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 import "AudioFormatSettings.proto";
 
 message VoiceInputDeviceDescriptor {


### PR DESCRIPTION
I have fixed a few syntax errors and commented out some fields (with currently missing tags) in order to make the .proto-files compilable. Added syntax as well to remove some warnings.

There is however one warning left:
```
$ protoc --python_out=tmp/ *.proto
RegisterVoiceInputDeviceMessage.proto:7:78: warning: Extension number 11 has already been used in "ProtocolMessage" by extension "registerHIDDeviceMessage" defined in RegisterHIDDeviceMessage.proto.
```
An ID collision seems to exist here:
```
$ egrep "optional .*= 11" *.proto | grep -v ProtocolMessage
RegisterHIDDeviceMessage.proto:  optional RegisterHIDDeviceMessage registerHIDDeviceMessage = 11;
RegisterVoiceInputDeviceMessage.proto:  optional RegisterVoiceInputDeviceMessage registerVoiceInputDeviceMessage = 11;
```
So I guess either one of RegisterHIDDeviceMessage or RegisterVoiceInputDeviceMessage should be using another ID. I haven't looked into which though.